### PR TITLE
removed non alpha character from SOAPAction for 3scale

### DIFF
--- a/configuration.lua
+++ b/configuration.lua
@@ -199,6 +199,7 @@ function _M.parse_service(service)
         local headerParams = ngx.req.get_headers()
         system_name = headerParams["SOAPAction"]
         if system_name~= nil then
+	  system_name = system_name:gsub('%W','')			
           check_soap(system_name, usage_t, matched_rules, params)
         end
 


### PR DESCRIPTION
Most of SOAP operations are using a namespace which has several special characters that can't be used in 3Scale metrics. 

Simple change to remove non-alphanumeric characters from the SOAPAction header.